### PR TITLE
Fully automate dev setup with Gitpod

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,7 @@
+FROM gitpod/workspace-full-vnc
+
+# Install custom tools, runtimes, etc.
+# For example "bastet", a command-line tetris clone:
+# RUN brew install bastet
+#
+# More information: https://www.gitpod.io/docs/config-docker/

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+image:
+  file: .gitpod.Dockerfile
+
+tasks:
+  - init: 'echo "TODO: Replace with init/build command"'
+    command: 'echo "TODO: Replace with command to start project"'

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/tronprotocol/tips)
+
 # TIPs
 
 TRON Improvement Proposals (TIPs) describe standards for the TRON platform, including core protocol specifications, client APIs, and contract standards.

--- a/tip-241.md
+++ b/tip-241.md
@@ -1,0 +1,26 @@
+```
+tip: 241
+title: Adaptation to solidity-v0.5.16
+author: yanghang8612<yanghang8612@163.com>
+status: Draft
+type: Standards Track
+category: VM
+created: 2021-03-08
+```
+
+## Simple Summary
+
+An adaptation to solidity-v0.5.16
+
+## Abstract
+
+Ethereum released version 0.5.16 of solidity to fix a bug. Solidity in tron should be updated to follow this release.
+
+##  Motivation
+
+The release of solidity-v0.5.16 means this bugfix about Yul Optimizer is very necessary. We should update solidity to follow this release as soon as possible.
+
+## Specification
+
+The Yul optimizer has a stage that removes assignments to variables that are overwritten again or are not used in all following control-flow branches. This logic incorrectly removes such assignments to variables declared inside a for loop if they can be removed in a control-flow branch that ends with ``break`` or ``continue`` even though they cannot be removed in other control-flow branches. Variables declared outside of the respective for loop are not affected. So we should update Tron Solidity to fix this bug.
+


### PR DESCRIPTION
This commit implements a fully-automated development setup using Gitpod.io, an
online IDE for GitLab, GitHub, and Bitbucket that enables Dev-Environments-As-Code.
This makes it easy for anyone to get a ready-to-code workspace for any branch,
issue or pull request almost instantly with a single click.